### PR TITLE
docs: add instruction for Android "tools" namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ react-native link react-native-wallet-passes
 
 #### Add following lines to AndroidManifest.xml
 
+If you don't already have the namespace `tools` defined in your `<manifest>` definition, add it now:
+
+```xml
+  <manifest ... xmlns:tools="http://schemas.android.com/tools" package="...">
+```
+
 ```diff
 <manifest ...>
   <application ...>


### PR DESCRIPTION
Some AndroidManifest.xml files might not have the "tools" namespace defined yet.
The new updated README helps them how to add this namespace.